### PR TITLE
Don't sync every cycle

### DIFF
--- a/src/Kaleidoscope-LEDControl.cpp
+++ b/src/Kaleidoscope-LEDControl.cpp
@@ -2,6 +2,8 @@
 
 LEDMode *LEDControl_::modes[LED_MAX_MODES];
 uint8_t LEDControl_::previousMode, LEDControl_::mode;
+uint16_t LEDControl_::syncDelay = 16;
+uint32_t LEDControl_::syncTimer;
 
 void
 LEDMode::activate (void) {
@@ -126,6 +128,8 @@ LEDControl_::begin (void) {
 
   event_handler_hook_use(eventHandler);
   loop_hook_use(loopHook);
+
+  syncTimer = millis();
 }
 
 Key
@@ -144,7 +148,10 @@ LEDControl_::loopHook (bool postClear) {
   if (postClear)
     return;
 
-  led_sync();
+  if (millis() - syncTimer >= syncDelay) {
+    led_sync();
+    syncTimer = millis();
+  }
   update();
 }
 

--- a/src/Kaleidoscope-LEDControl.cpp
+++ b/src/Kaleidoscope-LEDControl.cpp
@@ -129,7 +129,7 @@ LEDControl_::begin (void) {
   event_handler_hook_use(eventHandler);
   loop_hook_use(loopHook);
 
-  syncTimer = millis();
+  syncTimer = millis() + syncDelay;
 }
 
 Key
@@ -148,9 +148,9 @@ LEDControl_::loopHook (bool postClear) {
   if (postClear)
     return;
 
-  if (millis() - syncTimer >= syncDelay) {
+  if (millis() > syncTimer) {
     led_sync();
-    syncTimer = millis();
+    syncTimer = millis() + syncDelay;
   }
   update();
 }

--- a/src/Kaleidoscope-LEDControl.h
+++ b/src/Kaleidoscope-LEDControl.h
@@ -41,7 +41,10 @@ class LEDControl_ : public KaleidoscopePlugin {
 
     static void activate (LEDMode *mode);
 
+    static uint16_t syncDelay;
+
  private:
+    static uint32_t syncTimer;
     static LEDMode *modes[LED_MAX_MODES];
     static uint8_t previousMode, mode;
 


### PR DESCRIPTION
Because `led_sync` is a major cause of slowness, do not sync every cycle. In most cases, it is pointless to sync 100 times a second, about 60 - or even 30 - may be more than enough.

For this reason, introduce a timer, and a settable delay: we'll only call `led_sync` once the delay's up. It can be set to 0 to call it every time, but defaults to 16 (for about 62 syncs/sec), as a safe bet.

This speeds the loop up dramatically, except for the few exceptions where sync is called.

Fixes #1.
