### PR TITLE
LEDOff: Always set everything to off

### DIFF
--- a/src/LED-Off.cpp
+++ b/src/LED-Off.cpp
@@ -1,3 +1,7 @@
 #include "LED-Off.h"
 
+void LEDOff_::update (void) {
+  LEDControl.set_all_leds_to ({0, 0, 0});
+}
+
 LEDOff_ LEDOff;

--- a/src/LED-Off.h
+++ b/src/LED-Off.h
@@ -5,6 +5,8 @@
 class LEDOff_ : public LEDMode {
  public:
   LEDOff_ (void) { };
+
+  virtual void update (void) final;
 };
 
 extern LEDOff_ LEDOff;


### PR DESCRIPTION
While it was a neat optimization to only turn LEDs off at init time, that is not enough if there are other plugins in play, that work with the LEDs independently of the active LED mode. Such a plugin is LED-ActiveModColor, which never turns LEDs off, and relies on the LED mode to do that.

Since LEDOff did not turn things off on update(), when used together with LED-ActiveModColor, the LEDs under the modifiers stayed active, even after the modifiers went inactive.

With this simple change, LEDOff will now update, and the problem's gone.
