### PR TITLE
Add LEDControl.init_mode()

### DIFF
--- a/src/Kaleidoscope-LEDControl.cpp
+++ b/src/Kaleidoscope-LEDControl.cpp
@@ -52,6 +52,12 @@ LEDControl_::update(void) {
 }
 
 void
+LEDControl_::init_mode(void) {
+  if (modes[mode])
+    (modes[mode]->init)();
+}
+
+void
 LEDControl_::set_mode(uint8_t mode_) {
   if (mode_ < LED_MAX_MODES)
     mode = mode_;

--- a/src/Kaleidoscope-LEDControl.h
+++ b/src/Kaleidoscope-LEDControl.h
@@ -28,6 +28,7 @@ class LEDControl_ : public KaleidoscopePlugin {
   static void update(void);
   static void set_mode(uint8_t mode);
   static uint8_t get_mode();
+  static void init_mode(void);
 
   static int8_t mode_add(LEDMode *mode);
 


### PR DESCRIPTION
The new `init_mode()` method simply (re-)inits the current mode. Useful when a plugin that changes LEDs outside of LED modes wants to reset the active LED mode. Doubly useful when the active LED mode does all the work in its `init()` method.

Required for keyboardio/Kaleidoscope-Numlock#3.