### PR TITLE
Major update of how LED modes work

### DIFF
--- a/src/Kaleidoscope-LEDControl.h
+++ b/src/Kaleidoscope-LEDControl.h
@@ -8,27 +8,100 @@
 
 #define Key_LEDEffectNext (Key) { 0,  KEY_FLAGS | SYNTHETIC | IS_INTERNAL | LED_TOGGLE }
 
+namespace kaleidoscope {
+/** Base class for LED modes.
+ *
+ * LED modes are a special kind of plugin, they are in charge of updating LED
+ * colors, setting a theme. While it is possible to have other plugins
+ * override the mode's colors, the LED mode is the baseline.
+ *
+ * Most of its functionality is called via @ref LEDControl, with only a few
+ * public methods.
+ *
+ * A LED mode **must** implement at least one of @ref onActivate or @ref
+ * update, and possibly @ref refreshAt too.
+ */
 class LEDMode : public KaleidoscopePlugin {
- public:
-  virtual void begin(void);
+  friend class LEDControl;
+ protected:
+  // These methods should only be called by LEDControl.
+
+  /** One-time setup, called at keyboard boot.
+   *
+   * Any hooks that need registering, any one-time setup that needs to be
+   * performed, shall be done here. This is purely for preparation purposes, the
+   * LEDs should not be touched yet at this time.
+   */
   virtual void setup(void) {}
-  virtual void init(void) {}
+
+  /** Function to call whenever the mode is activated.
+   *
+   * Like @ref setup, this method need not touch LEDs, @ref update will be
+   * called right after it. The purpose of this callback is to allow a plugin to
+   * do some preparation whenever it is activated, instead of only on boot, or
+   * always at each cycle.
+   *
+   * However, unlike @ref setup, this method can change LED colors, if so
+   * desired. Either to provide an initial state, or a static color set. In the
+   * latter case, consider implementing @ref refreshAt too, because other
+   * plugins may override some of the colors set at activation time, and @ref
+   * refreshAt can be used to restore them when needed.
+   *
+   * Before the callback runs, LEDs will be blanked.
+   */
+  virtual void onActivate(void) {}
+
+  /** Update the LEDs once per cycle.
+   *
+   * Usually the brains of the plugin, which updates the LEDs each cycle. It is
+   * called after the matrix has been scanned, once per cycle.
+   */
   virtual void update(void) {}
-  virtual void activate(void);
+
+  /** Refresh the color of a given key.
+   *
+   * If we have another plugin that overrides colors set by the active LED mode
+   * (either at @onActivate time, or via @ref update), if that plugin wants to
+   * restore whatever color the mode would set the key color to, this is the
+   * method it will call.
+   *
+   * @param row is the row coordinate of the key to refresh the color of.
+   * @param col is the column coordinate of the key to refresh the color of.
+   */
+  virtual void refreshAt(byte row, byte col) {}
+
+ public:
+  /** Activate the current object as the LED mode.
+   */
+  void activate(void);
+
+  /** Plugin initialization.
+   *
+   * Called via `Kaleidoscope.use()`, registers the LED mode, and does the
+   * necessary initialization steps. Calls @ref setup at the end.
+   */
+  void begin(void) final;
 };
 
-class LEDControl_ : public KaleidoscopePlugin {
+class LEDControl : public KaleidoscopePlugin {
  public:
-  LEDControl_(void);
+  LEDControl(void);
 
   void begin(void) final;
 
   static void next_mode(void);
   static void setup(void);
-  static void update(void);
+  static void update(void) {
+    if (modes[mode])
+      modes[mode]->update();
+  }
+  static void refreshAt(byte row, byte col) {
+    if (modes[mode])
+      modes[mode]->refreshAt(row, col);
+  }
   static void set_mode(uint8_t mode);
-  static uint8_t get_mode();
-  static void init_mode(void);
+  static uint8_t get_mode_index();
+  static LEDMode *get_mode();
 
   static int8_t mode_add(LEDMode *mode);
 
@@ -49,13 +122,14 @@ class LEDControl_ : public KaleidoscopePlugin {
  private:
   static uint32_t syncTimer;
   static LEDMode *modes[LED_MAX_MODES];
-  static uint8_t previousMode, mode;
+  static uint8_t mode;
 
   static Key eventHandler(Key mappedKey, byte row, byte col, uint8_t keyState);
   static void loopHook(bool postClear);
 };
+}
 
-extern LEDControl_ LEDControl;
+extern kaleidoscope::LEDControl LEDControl;
 
 #define FOCUS_HOOK_LEDCONTROL FOCUS_HOOK (LEDControl.focusHook, \
                                           "led.at\n"            \

--- a/src/LED-Off.cpp
+++ b/src/LED-Off.cpp
@@ -1,7 +1,13 @@
 #include "LED-Off.h"
 
-void LEDOff_::update(void) {
-  LEDControl.set_all_leds_to({0, 0, 0});
+namespace kaleidoscope {
+void LEDOff::onActivate(void) {
+  ::LEDControl.set_all_leds_to({0, 0, 0});
 }
 
-LEDOff_ LEDOff;
+void LEDOff::refreshAt(byte row, byte col) {
+  ::LEDControl.setCrgbAt(row, col, {0, 0, 0});
+}
+}
+
+kaleidoscope::LEDOff LEDOff;

--- a/src/LED-Off.h
+++ b/src/LED-Off.h
@@ -2,11 +2,15 @@
 
 #include "Kaleidoscope-LEDControl.h"
 
-class LEDOff_ : public LEDMode {
+namespace kaleidoscope {
+class LEDOff : public LEDMode {
  public:
-  LEDOff_(void) { }
+  LEDOff(void) { }
 
-  void update(void) final;
+ protected:
+  void onActivate(void) final;
+  void refreshAt(byte row, byte col) final;
 };
+}
 
-extern LEDOff_ LEDOff;
+extern kaleidoscope::LEDOff LEDOff;


### PR DESCRIPTION
There were a number of issues with the model we had before, namely that plugins that changed LED colors outside of LED modes had no way to signal "go back to whatever color this key was". To this end, the `LEDMode.refreshAt` method is introduced, which these plugins can call to tell the mode to update a given key.

As part of this, the API was redesigned, with code that is common between all LED modes moving to the base class, among other things, much better names, and a flow of control that is easier to follow.

In the new setup, there are four methods a LED mode can implement:

- `setup()` to do boot-time initialization (registering hooks, etc).
- `onActivate()` called every time the mode is activated.
- `update()` called each cycle.
- `refreshAt()` may be called by other plugins to refresh a particular key.

All of these are protected methods, to be called via `LEDControl` only.

Much of the new API design was done by @cdisselkoen, huge thanks for his work!

Fixes #9.
