### PR TITLE
Remove some dead code that were accidentally left in

### DIFF
--- a/src/Kaleidoscope-LEDControl.cpp
+++ b/src/Kaleidoscope-LEDControl.cpp
@@ -33,18 +33,6 @@ void LEDControl::next_mode(void) {
   return set_mode(mode);
 }
 
-#if 0
-void LEDControl::update(void) {
-  if (modes[mode])
-    (modes[mode]->update)();
-}
-
-void LEDControl::refreshAt(byte row, byte col) {
-  if (modes[mode])
-    modes[mode]->refreshAt(row, col);
-}
-#endif
-
 void
 LEDControl::set_mode(uint8_t mode_) {
   if (mode_ >= LED_MAX_MODES)


### PR DESCRIPTION
When implementing `.refreshAt` before, some dead code was left in Kaleidoscope-LEDControl.cpp, code that is now implemented in the header.

As these are implemented elsewhere, and are `#if 0`'d out anyway, drop them.
