### PR TITLE
Add LEDControl.reActivate()

### DIFF
--- a/src/Kaleidoscope-LEDControl.cpp
+++ b/src/Kaleidoscope-LEDControl.cpp
@@ -50,10 +50,8 @@ LEDControl::set_mode(uint8_t mode_) {
   if (mode_ >= LED_MAX_MODES)
     return;
 
-  set_all_leds_to({0, 0, 0});
   mode = mode_;
-  if (modes[mode])
-    modes[mode]->onActivate();
+  reactivate();
 }
 
 uint8_t LEDControl::get_mode_index(void) {

--- a/src/Kaleidoscope-LEDControl.h
+++ b/src/Kaleidoscope-LEDControl.h
@@ -102,6 +102,11 @@ class LEDControl : public KaleidoscopePlugin {
   static void set_mode(uint8_t mode);
   static uint8_t get_mode_index();
   static LEDMode *get_mode();
+  static void reactivate() {
+    set_all_leds_to({0, 0, 0});
+    if (modes[mode])
+      modes[mode]->onActivate();
+  }
 
   static int8_t mode_add(LEDMode *mode);
 


### PR DESCRIPTION
Intended to force-reactivate the current LED mode, in case we want to refresh the whole board, and make sure we do so even if the current mode's update is a no-op.

This can happen when we overrode some keys, and it becomes less costly to update everything than to iterate over the updated keys.
