### PR TITLE
Add a way to pause LED modes

### DIFF
--- a/src/Kaleidoscope-LEDControl.cpp
+++ b/src/Kaleidoscope-LEDControl.cpp
@@ -7,6 +7,7 @@ LEDMode *LEDControl::modes[LED_MAX_MODES];
 uint8_t LEDControl::mode;
 uint16_t LEDControl::syncDelay = 16;
 uint32_t LEDControl::syncTimer;
+bool LEDControl::paused = false;
 
 void LEDMode::activate(void) {
   ::LEDControl.activate(this);
@@ -123,7 +124,7 @@ Key LEDControl::eventHandler(Key mappedKey, byte row, byte col, uint8_t keyState
 }
 
 void LEDControl::loopHook(bool postClear) {
-  if (postClear)
+  if (postClear || paused)
     return;
 
   if (millis() > syncTimer) {

--- a/src/Kaleidoscope-LEDControl.h
+++ b/src/Kaleidoscope-LEDControl.h
@@ -103,6 +103,9 @@ class LEDControl : public KaleidoscopePlugin {
   static uint8_t get_mode_index();
   static LEDMode *get_mode();
   static void refreshAll() {
+    if (paused)
+      return;
+
     set_all_leds_to({0, 0, 0});
     if (modes[mode])
       modes[mode]->onActivate();
@@ -121,6 +124,7 @@ class LEDControl : public KaleidoscopePlugin {
   static void activate(LEDMode *mode);
 
   static uint16_t syncDelay;
+  static bool paused;
 
   static bool focusHook(const char *command);
 


### PR DESCRIPTION
Add LEDControl.paused, which we use to pause LED mode updates if true (defaults to false). This is useful when we want to stop LED modes from updating without switching to another (like when the host goes to sleep, and we want to turn LEDs off).