### PR TITLE
added prev_mode

### DIFF
--- a/src/Kaleidoscope-LEDControl.cpp
+++ b/src/Kaleidoscope-LEDControl.cpp
@@ -130,8 +130,12 @@ Key LEDControl::eventHandler(Key mappedKey, byte row, byte col, uint8_t keyState
   if (mappedKey.flags != (SYNTHETIC | IS_INTERNAL | LED_TOGGLE))
     return mappedKey;
 
-  if (keyToggledOn(keyState))
-    next_mode();
+  if (keyToggledOn(keyState)) {
+    if (mappedKey == Key_LEDEffectNext)
+      next_mode();
+    else
+      prev_mode();
+  }
 
   return Key_NoKey;
 }

--- a/src/Kaleidoscope-LEDControl.cpp
+++ b/src/Kaleidoscope-LEDControl.cpp
@@ -34,6 +34,16 @@ void LEDControl::next_mode(void) {
   return set_mode(mode);
 }
 
+void LEDControl::prev_mode(void) {
+  mode--;
+
+  if (mode >= LED_MAX_MODES || !modes[mode]) {
+    return set_mode(0);
+  }
+
+  return set_mode(mode);
+}
+
 void
 LEDControl::set_mode(uint8_t mode_) {
   if (mode_ >= LED_MAX_MODES)

--- a/src/Kaleidoscope-LEDControl.cpp
+++ b/src/Kaleidoscope-LEDControl.cpp
@@ -131,10 +131,11 @@ Key LEDControl::eventHandler(Key mappedKey, byte row, byte col, uint8_t keyState
     return mappedKey;
 
   if (keyToggledOn(keyState)) {
-    if (mappedKey.keyCode == 0)
+    if (mappedKey == Key_LEDEffectNext) {
       next_mode();
-    else
+    } else if (mappedKey == Key_LEDEffectPrevious) {
       prev_mode();
+    }
   }
 
   return Key_NoKey;

--- a/src/Kaleidoscope-LEDControl.cpp
+++ b/src/Kaleidoscope-LEDControl.cpp
@@ -35,13 +35,15 @@ void LEDControl::next_mode(void) {
 }
 
 void LEDControl::prev_mode(void) {
-  mode--;
-
-  if (mode >= LED_MAX_MODES || !modes[mode]) {
-    return set_mode(0);
+  if (mode == 0) {
+    // wrap around
+    mode = LED_MAX_MODES;
+    // then  count down until reaching a valid mode
+    while (mode > 0 && !modes[mode]) mode--;
+  } else {
+    mode--;
   }
-
-  return set_mode(mode);
+  set_mode(mode);
 }
 
 void

--- a/src/Kaleidoscope-LEDControl.cpp
+++ b/src/Kaleidoscope-LEDControl.cpp
@@ -131,7 +131,7 @@ Key LEDControl::eventHandler(Key mappedKey, byte row, byte col, uint8_t keyState
     return mappedKey;
 
   if (keyToggledOn(keyState)) {
-    if (mappedKey == Key_LEDEffectNext)
+    if (mappedKey.keyCode == 0)
       next_mode();
     else
       prev_mode();

--- a/src/Kaleidoscope-LEDControl.cpp
+++ b/src/Kaleidoscope-LEDControl.cpp
@@ -37,13 +37,14 @@ void LEDControl::next_mode(void) {
 void LEDControl::prev_mode(void) {
   if (mode == 0) {
     // wrap around
-    mode = LED_MAX_MODES;
+    mode = LED_MAX_MODES - 1;
     // then  count down until reaching a valid mode
     while (mode > 0 && !modes[mode]) mode--;
   } else {
     mode--;
   }
-  set_mode(mode);
+
+  return set_mode(mode);
 }
 
 void

--- a/src/Kaleidoscope-LEDControl.h
+++ b/src/Kaleidoscope-LEDControl.h
@@ -7,6 +7,7 @@
 #define LED_TOGGLE   B00000001  // Synthetic, internal
 
 #define Key_LEDEffectNext (Key) { 0,  KEY_FLAGS | SYNTHETIC | IS_INTERNAL | LED_TOGGLE }
+#define Key_LEDEffectPrevious (Key) { 1,  KEY_FLAGS | SYNTHETIC | IS_INTERNAL | LED_TOGGLE }
 
 namespace kaleidoscope {
 /** Base class for LED modes.

--- a/src/Kaleidoscope-LEDControl.h
+++ b/src/Kaleidoscope-LEDControl.h
@@ -90,6 +90,7 @@ class LEDControl : public KaleidoscopePlugin {
   void begin(void) final;
 
   static void next_mode(void);
+  static void prev_mode(void);
   static void setup(void);
   static void update(void) {
     if (modes[mode])

--- a/src/LEDUtils.cpp
+++ b/src/LEDUtils.cpp
@@ -17,7 +17,7 @@ breath_compute() {
 
   i = (((3 * (uint16_t)(ii)) - (2 * (uint16_t)(iii))) / 2) + 80;
 
-  return hsvToRgb(170, 255, i);
+  return hsvToRgb(230, 255, i);
 }
 
 


### PR DESCRIPTION
I'd like to be able to add a macro that makes the LED modes cycle backwards. This PR *should* do that. But also, please _don't merge it yet_, as it's not yet working as intended -- in particular, calling `prev_mode` appears to cause the mode to be set to zero? I can't figure out why. Any guesses?