### PR TITLE
Enable focus command `led.mode p`

### DIFF
--- a/src/Kaleidoscope-LEDControl.cpp
+++ b/src/Kaleidoscope-LEDControl.cpp
@@ -212,7 +212,7 @@ bool LEDControl::focusHook(const char *command) {
       next_mode();
       Serial.read();
     } else if (peek == 'p') {
-      // TODO(algernon)
+      prev_mode();
       Serial.read();
     } else {
       uint8_t mode = Serial.parseInt();


### PR DESCRIPTION
Since `prev_mode` was implemented, this makes fixing this TODO much easier :)

Tested on hardware.

cc @algernon 