### PR TITLE
Fixed syncTimer overflow condition

### DIFF
--- a/src/Kaleidoscope-LEDControl.cpp
+++ b/src/Kaleidoscope-LEDControl.cpp
@@ -6,7 +6,7 @@ namespace kaleidoscope {
 LEDMode *LEDControl::modes[LED_MAX_MODES];
 uint8_t LEDControl::mode;
 uint16_t LEDControl::syncDelay = 16;
-uint32_t LEDControl::syncTimer;
+uint16_t LEDControl::syncTimer;
 bool LEDControl::paused = false;
 
 void LEDMode::activate(void) {
@@ -145,9 +145,10 @@ void LEDControl::loopHook(bool postClear) {
   if (postClear || paused)
     return;
 
-  if (millis() > syncTimer) {
+  uint16_t current_time = millis();
+  if ((current_time - syncTimer) > syncDelay) {
     syncLeds();
-    syncTimer = millis() + syncDelay;
+    syncTimer += syncDelay;
   }
   update();
 }

--- a/src/Kaleidoscope-LEDControl.h
+++ b/src/Kaleidoscope-LEDControl.h
@@ -131,7 +131,7 @@ class LEDControl : public KaleidoscopePlugin {
   static bool focusHook(const char *command);
 
  private:
-  static uint32_t syncTimer;
+  static uint16_t syncTimer;
   static LEDMode *modes[LED_MAX_MODES];
   static uint8_t mode;
 


### PR DESCRIPTION
This prevents an insignificant error, but it is more correct to handle the integer overflow instead of ignoring it. I've also changed syncTimer from a 32-bit to 16-bit integer, which results in a smaller code size, and changed the computation of the timeout slightly, so the LED update interval is always the same (we add `syncDelay` to the previous update's start time, not it's end time), rather than varying based on when LEDControl's `loopHook()` function is called relative to the last timeout.