### PR TITLE
Fixed brightness jump on overflow

### DIFF
--- a/src/LEDUtils.cpp
+++ b/src/LEDUtils.cpp
@@ -5,7 +5,9 @@ breath_compute() {
   // This code is adapted from FastLED lib8tion.h as of dd5d96c6b289cb6b4b891748a4aeef3ddceaf0e6
   // Eventually, we should consider just using FastLED
 
-  uint8_t i = (uint16_t)millis() / 12;
+  // We do a bit shift here instead of division to ensure that there's no discontinuity
+  // in the output brightness when the integer overflows.
+  uint8_t i = (uint16_t)millis() >> 4;
 
   if (i & 0x80) {
     i = 255 - i;


### PR DESCRIPTION
With the previous algorithm, once every 65 seconds, there would be a significant jump in the brightness of the "breathing" LEDs as the 16-bit value recorded from `millis()` overflowed. Instead of dividing by 12, I changed it to a division by 16, which alters the timing slightly, but prevents the sudden jump because a division by 16 is simply a bit shift, so when the integer overflow occurs, the next value is what it should be.

With this change, the "breathing" is a bit slower, but still on a very similar scale. I also tested division by 8, but that was much too fast. Personally, I prefer the slightly slower effect, though I'm not sure I would be able to tell you which speed it was if I looked at it in isolation.

Fixes #20.